### PR TITLE
Apply adjustment recommended by Prof. Seamons

### DIFF
--- a/07-hw-sockets/README.md
+++ b/07-hw-sockets/README.md
@@ -475,7 +475,7 @@ connection with the remote side.
    bytes read, so the bytes read are placed in the buffer immediately following
    bytes previously read.  For example:
    ```c
-   read(fd, buf + tot_bytes_read, bytes_to_read);
+   read(fd, buf + tot_bytes_read, bytes_to_read - tot_bytes_read);
    ```
  - After _all_ the data has been read from standard input (i.e., EOF has been
    reached), write another loop to send all the data that was received (i.e.,


### PR DESCRIPTION
On repeated calls to finish reading information into the buffer, the total size remaining in the buffer has decreased. Always suggesting that `bytes_to_read` is constant while the buffer is filling up... is a buffer overflow bug. It is better not to demonstrate buggy code to students just learning these concepts.